### PR TITLE
update DB schema

### DIFF
--- a/orion/model.py
+++ b/orion/model.py
@@ -100,8 +100,8 @@ class Dataset(Document, MongoUtils):
     start_time = fields.IntField()
     stop_time = fields.IntField()
     data_location = fields.StringField()
-    timestamp_column = fields.IntField()
-    value_column = fields.IntField()
+    timestamp_column = fields.IntField(default=0)
+    value_column = fields.IntField(default=1)
     created_by = fields.StringField()
 
 
@@ -124,6 +124,7 @@ class Datarun(Document, MongoUtils):
     events = fields.IntField()
     status = fields.StringField()
     created_by = fields.StringField()
+    experiment = fields.StringField()
 
 
 class Event(Document, MongoUtils):
@@ -138,3 +139,41 @@ class Comment(Document, MongoUtils):
     event = fields.ReferenceField(Event)
     text = fields.StringField(required=True)
     created_by = fields.StringField()
+
+
+class Experiment(Document, MongoUtils):
+    name = fields.StringField(required=True, unique=True)
+    model_num = fields.IntField(required=True)
+    event_num = fields.IntField(required=True)
+    pipeline = fields.ReferenceField(Pipeline)
+    project = fields.StringField()
+    dataruns = fields.ListField(fields.ReferenceField(Datarun))
+    start_time = fields.DateTimeField(required=True)
+    end_time = fields.DateTimeField()
+    status = fields.StringField()
+    created_by = fields.StringField()
+
+class Raw(Document, MongoUtils):
+    dataset = fields.StringField()
+    timestamp = fields.FloatField()
+    year = fields.IntField()
+    data = fields.ListField(fields.ListField())
+    # meta = {
+    #     'indexes': [
+    #         '$dataset', # text index
+    #         ('dataset', '+year')
+    #     ]
+    # }
+
+
+class Prediction(Document, MongoUtils):
+    dataset = fields.StringField()
+    datarun = fields.ReferenceField(Datarun)
+    offset = fields.IntField()
+    names = fields.ListField(fields.ListField(fields.DictField()))
+    data = fields.ListField(fields.ListField(fields.FloatField()))
+    meta = {
+        'indexes': [
+            '$dataset'  # text index
+        ]
+    }


### PR DESCRIPTION
When we are using Orion, the logic we follow is that:

**step0:** we already have many datasets (one dataset is one signal) and pipelines;

**step1:** we create a new project say “NASA”;

**step2:** for a created project, we can run multiple different experiments. Each experiment will use the same pipeline running on different datasets. "Datarun" is the term used to describe the behavior of running a specific pipeline on a certain dataset. Thus, in one experiment, multiple dataruns would be generated.

**Therefore, I slightly changed the DB schema to fit this logic.**

In addition, there are two additional collections "Raw" and "Prediction", storing the time series data of every signal after aggregation and model's prediction results, respectively. These data will be used for visualization.

The example db could be found:
        curl -o nasa.tar.bz2 "http://dongyu.name/data/nasa"
	tar -xvf nasa.tar.bz2 && rm nasa.tar.bz2
	mongorestore --db nasa ./nasa/

**----------------------- important --------------------**
I did not push the changes on other files for dumping data with the new schema, as I change many unnecessary parts of the code for experimental use. 

I share my forked version of Orion with all the changes to Carles and Alex, where I mainly add a primitive called "data_dumper" to dump all required data to mongodb. But this could not be the optimal solution, as I have to add several ugly intermedia primitives to explicitly save some useful data to context variables, because I don't want to change any lines of the originally integrated primitives.

@csala and @AlexanderGeiger  Can you give suggestions on this so that we can find a better way to dump the required data?



